### PR TITLE
Enable per-agent commands

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -4,6 +4,7 @@ This module exports the main agents used in the application.
 """
 
 from .workflow import universal_workflow, UniversalAgentWorkflow
+from .base_implementation import create_agent
 
 __all__ = [
     "universal_workflow",
@@ -33,3 +34,33 @@ __all__.extend(
         "advertising_strategist_agent_profile",
     ]
 )
+
+# Individual agent workflows for direct invocation
+ideation_workflow = create_agent(ideation_agent_profile)
+idea_analysis_workflow = create_agent(idea_analysis_agent_profile)
+product_manager_workflow = create_agent(product_manager_agent_profile)
+strategic_advisor_workflow = create_agent(strategic_advisor_agent_profile)
+landing_page_workflow = create_agent(landing_page_designer_agent_profile)
+cto_workflow = create_agent(cto_agent_profile)
+advertising_strategist_workflow = create_agent(advertising_strategist_agent_profile)
+
+agent_workflows = {
+    "ideation": ideation_workflow,
+    "ideaanalysis": idea_analysis_workflow,
+    "productmanager": product_manager_workflow,
+    "strategicadvisor": strategic_advisor_workflow,
+    "landingpage": landing_page_workflow,
+    "cto": cto_workflow,
+    "advertisingstrategist": advertising_strategist_workflow,
+}
+
+__all__.extend([
+    "agent_workflows",
+    "ideation_workflow",
+    "idea_analysis_workflow",
+    "product_manager_workflow",
+    "strategic_advisor_workflow",
+    "landing_page_workflow",
+    "cto_workflow",
+    "advertising_strategist_workflow",
+])


### PR DESCRIPTION
## Summary
- add simple agent prefix handling in chat processing
- expose single-agent workflows for direct use
- extend base workflow to accept memory for chat history

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt` *(partial output shown)*

------
https://chatgpt.com/codex/tasks/task_e_683f8c3b4a04833293ce3ab20498afe1